### PR TITLE
Fix type alignment and passing semantics

### DIFF
--- a/expected/duration.out
+++ b/expected/duration.out
@@ -294,3 +294,18 @@ SELECT DURATION '1 minute' <> DURATION '1 us';
  t
 (1 row)
 
+-- Inserts
+DROP SCHEMA IF EXISTS regress CASCADE;
+NOTICE:  schema "regress" does not exist, skipping
+CREATE SCHEMA regress;
+CREATE TABLE regress.t (d1 DURATION, d2 DURATION);
+INSERT INTO regress.t VALUES ('1 s 6 m'), ('500ms 4 h');
+SELECT * FROM regress.t;
+         d1         | d2 
+--------------------+----
+ @ 6 mins 1 sec     | 
+ @ 4 hours 0.5 secs | 
+(2 rows)
+
+DROP SCHEMA regress CASCADE;
+NOTICE:  drop cascades to table regress.t

--- a/pg_duration--1.0.sql
+++ b/pg_duration--1.0.sql
@@ -87,7 +87,8 @@ CREATE TYPE duration (
     OUTPUT = duration_out,
     RECEIVE = duration_recv,
     SEND = duration_send,
-    ALIGNMENT = int4
+    PASSEDBYVALUE,
+    ALIGNMENT = double
 );
 
 COMMENT ON TYPE duration IS 'duration of time';

--- a/sql/duration.sql
+++ b/sql/duration.sql
@@ -65,3 +65,11 @@ SELECT DURATION '1 minute' = DURATION '1 us';
 SELECT DURATION '1 sec' <> DURATION '1 hour';
 SELECT DURATION '1 millisecond' <> DURATION '1 ms';
 SELECT DURATION '1 minute' <> DURATION '1 us';
+
+-- Inserts
+DROP SCHEMA IF EXISTS regress CASCADE;
+CREATE SCHEMA regress;
+CREATE TABLE regress.t (d1 DURATION, d2 DURATION);
+INSERT INTO regress.t VALUES ('1 s 6 m'), ('500ms 4 h');
+SELECT * FROM regress.t;
+DROP SCHEMA regress CASCADE;


### PR DESCRIPTION
Previously, the duration type was created with a 4 byte alignment as
was specified as pass by reference. This was incorrect because
durations are 8 bytes and passed by value. This commit fixes the issue
which also fixes the segfault that would happen when inserting
durations into tables.

Fixes #1